### PR TITLE
test: add model output consistency checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,6 @@ jobs:
     timeout-minutes: 30
     env:
       MPLBACKEND: Agg
-      MPLCONFIGDIR: ${{ runner.temp }}/matplotlib
-      XDG_CACHE_HOME: ${{ runner.temp }}/cache
 
     steps:
       - uses: actions/checkout@v7
@@ -29,6 +27,11 @@ jobs:
             requirements.txt
             requirements-test.txt
             pyproject.toml
+
+      - name: Configure runtime directories
+        run: |
+          echo "MPLCONFIGDIR=${RUNNER_TEMP}/matplotlib" >> "${GITHUB_ENV}"
+          echo "XDG_CACHE_HOME=${RUNNER_TEMP}/cache" >> "${GITHUB_ENV}"
 
       - name: Install package and test dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  python-311:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      MPLBACKEND: Agg
+      MPLCONFIGDIR: ${{ runner.temp }}/matplotlib
+      XDG_CACHE_HOME: ${{ runner.temp }}/cache
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11.15"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-test.txt
+            pyproject.toml
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install -r requirements-test.txt
+          python -m pip install -e . --no-deps
+
+      - name: Check installed dependencies
+        run: python -m pip check
+
+      - name: Run test suite and create impact reports
+        run: python -m pytest --impact-report=impact-report
+
+      - name: Build wheel from maintained sources
+        run: python -m pip wheel . --no-deps --wheel-dir wheelhouse
+
+      - name: Verify wheel contents
+        run: python tests/verify_wheel.py wheelhouse/*.whl
+
+      - name: Preserve numerical impact reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: model-impact-python-3.11
+          path: impact-report/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 __pycache__/
 *.py[cod]
+.venv/
+.pytest_cache/
+.coverage
+htmlcov/
+impact-report/
 
 build/
 dist/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,10 @@ MATILDA is a Python-based modeling framework for simulating water resources in g
    :caption: Documentation
 
    Getting started <readme>
+   Testing and impact reports <testing>
 
 .. toctree::
    :maxdepth: 1
    :caption: MATILDA Modules
 
-   matilda  
+   matilda

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,66 @@
+# Testing and numerical impact reports
+
+MATILDA's characterization suite protects the complete numerical result of a
+standard 2000–2020 glacier-evolution simulation. It compares the compact and
+full daily process tables, KGE, summary statistics, glacier elevation
+distribution, and annual glacier evolution. Dates, column order, data types,
+and missing-value positions are part of the reference contract.
+
+## Local Python 3.11 environment
+
+The maintained characterization environment uses Python 3.11.15. Create an
+isolated environment from that interpreter and install the pinned test tools:
+
+```bash
+python3.11 -m venv .venv
+.venv/bin/python -m pip install -r requirements-test.txt
+.venv/bin/python -m pip install -e . --no-deps
+.venv/bin/python -m pip check
+```
+
+Run all tests with:
+
+```bash
+.venv/bin/python -m pytest
+```
+
+The test requirements pin the direct and secondary dependencies used for the
+numerical reference. The `.venv/` directory is local and is excluded from
+version control.
+
+## Quantifying the effect of model changes
+
+To compare the working implementation with the maintained reference and write
+detailed reports, run:
+
+```bash
+.venv/bin/python -m pytest --impact-report=impact-report
+```
+
+The command writes three files:
+
+- `variable_impact.csv` reports the number of changed values, maximum absolute
+  change, mean absolute change, RMSE, changes in totals and means, and the first
+  affected index for every output variable.
+- `annual_impact.csv` reports pointwise, mean, and total changes by calendar
+  year for outputs with date indexes.
+- `summary.json` lists the affected model-process groups.
+
+These reports are intended to show which processes, variables, and periods are
+affected by a change. They can therefore guide decisions about which figures,
+tables, calibrations, or catchment simulations need to be repeated.
+
+## Reference policy
+
+The reference file has a recorded checksum and must not be replaced merely to
+make a changed test pass. When an intentional scientific correction changes
+the output, retain its impact reports for review first. Update the reference
+only after the scientific consequences and compatibility implications have
+been accepted.
+
+The current reference covers one long glacier-evolution scenario. Separate
+tests are still required before changing zero-glacier, full-glacier,
+fixed-elevation, short-period, and calibration pathways.
+
+The continuous-integration workflow also builds a wheel and verifies that its
+package files are byte-for-byte copies of the maintained sources.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,14 +1,14 @@
 # Testing and numerical impact reports
 
-MATILDA's characterization suite protects the complete numerical result of a
-standard 2000–2020 glacier-evolution simulation. It compares the compact and
-full daily process tables, KGE, summary statistics, glacier elevation
+MATILDA's model output consistency tests protect the complete numerical result
+of a standard 2000–2020 glacier-evolution simulation. It compares the compact
+and full daily process tables, KGE, summary statistics, glacier elevation
 distribution, and annual glacier evolution. Dates, column order, data types,
 and missing-value positions are part of the reference contract.
 
 ## Local Python 3.11 environment
 
-The maintained characterization environment uses Python 3.11.15. Create an
+The maintained test environment uses Python 3.11.15. Create an
 isolated environment from that interpreter and install the pinned test tools:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 requires = ["setuptools", "wheel"]  # Add required build tools
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--strict-markers -ra"
+markers = [
+    "characterization: full-model comparisons against the maintained numerical reference",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "setuptools.build_meta"
 testpaths = ["tests"]
 addopts = "--strict-markers -ra"
 markers = [
-    "characterization: full-model comparisons against the maintained numerical reference",
+    "model_consistency: full-model comparisons against the maintained numerical reference",
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,19 @@
+-r requirements.txt
+
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.63.0
+iniconfig==2.3.0
+kiwisolver==1.5.0
+packaging==26.2
+pillow==12.3.0
+pluggy==1.6.0
+Pygments==2.20.0
+pyparsing==3.3.2
+pytest==9.1.1
+python-dateutil==2.9.0.post0
+pytz==2026.3.post1
+six==1.17.0
+tenacity==9.1.4
+tzdata==2026.3
+zope.interface==8.5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test support for the standalone MATILDA package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Shared fixtures and command-line options for MATILDA tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+os.environ.setdefault(
+    "MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "matilda-matplotlib")
+)
+os.environ.setdefault(
+    "XDG_CACHE_HOME", str(Path(tempfile.gettempdir()) / "matilda-cache")
+)
+
+from tests.scenario import MANIFEST_PATH, load_reference, run_reference_scenario
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--impact-report",
+        action="store",
+        default=None,
+        metavar="DIRECTORY",
+        help="write per-variable and annual model-impact CSV reports",
+    )
+
+
+@pytest.fixture(scope="session")
+def reference_manifest():
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def reference_output():
+    return load_reference()
+
+
+@pytest.fixture(scope="session")
+def current_output():
+    return run_reference_scenario()
+
+
+@pytest.fixture(scope="session")
+def impact_report_directory(pytestconfig):
+    value = pytestconfig.getoption("--impact-report")
+    return Path(value).resolve() if value else None

--- a/tests/impact.py
+++ b/tests/impact.py
@@ -1,0 +1,389 @@
+"""Detailed numerical impact reporting for MATILDA characterization outputs."""
+
+from __future__ import annotations
+
+from importlib import metadata
+import json
+from pathlib import Path
+import platform
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
+from pandas.testing import assert_frame_equal
+
+
+FRAME_OUTPUTS = {
+    0: "compact_daily",
+    1: "full_daily",
+    3: "summary_statistics",
+    4: "glacier_elevation_distribution",
+    5: "annual_glacier_evolution",
+}
+
+
+def classify_process(output_name: str, variable: object) -> str:
+    """Assign a broad process label for sorting impact reports."""
+    name = str(variable).lower()
+    if output_name.startswith("glacier_") or any(
+        token in name
+        for token in (
+            "ddm_",
+            "smb",
+            "on_glaciers",
+            "glacier_area",
+            "glacier_elev",
+            "glacier_mass",
+            "glacier_vol",
+            "ice_melt",
+        )
+    ):
+        return "glacier"
+    if any(token in name for token in ("runoff", "q_hbv", "q_total", "qobs")):
+        return "runoff"
+    if any(token in name for token in ("groundwater", "upper_gw", "lower_gw")):
+        return "groundwater"
+    if "soil" in name:
+        return "soil"
+    if any(token in name for token in ("evap", "aet", "hbv_pe")):
+        return "evapotranspiration"
+    if any(token in name for token in ("snow", "melt", "refreez")):
+        return "snow_and_melt"
+    if any(token in name for token in ("prec", "rain")):
+        return "precipitation"
+    if any(token in name for token in ("temp", "pdd")):
+        return "temperature"
+    return "diagnostic"
+
+
+def _safe_float(value) -> float:
+    return float(value) if pd.notna(value) else np.nan
+
+
+def _sum(series: pd.Series) -> float:
+    return _safe_float(series.sum(min_count=1))
+
+
+def _comparison_mask(
+    reference: pd.Series,
+    current: pd.Series,
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    reference_aligned, current_aligned = reference.align(current, join="outer")
+    same = reference_aligned.eq(current_aligned) | (
+        reference_aligned.isna() & current_aligned.isna()
+    )
+    reference_present = pd.Series(
+        reference_aligned.index.isin(reference.index), index=reference_aligned.index
+    )
+    current_present = pd.Series(
+        current_aligned.index.isin(current.index), index=current_aligned.index
+    )
+    same &= reference_present & current_present
+    return reference_aligned, current_aligned, same
+
+
+def _missing_column_row(
+    output_name: str,
+    variable: object,
+    status: str,
+    reference: pd.DataFrame,
+    current: pd.DataFrame,
+) -> dict:
+    return {
+        "output": output_name,
+        "process": classify_process(output_name, variable),
+        "variable": str(variable),
+        "status": status,
+        "reference_dtype": (
+            str(reference[variable].dtype) if variable in reference else ""
+        ),
+        "current_dtype": str(current[variable].dtype) if variable in current else "",
+        "index_equal": reference.index.equals(current.index),
+        "reference_rows": len(reference),
+        "current_rows": len(current),
+        "reference_missing": (
+            int(reference[variable].isna().sum()) if variable in reference else np.nan
+        ),
+        "current_missing": (
+            int(current[variable].isna().sum()) if variable in current else np.nan
+        ),
+        "changed_count": max(len(reference), len(current)),
+        "max_abs_change": np.nan,
+        "mean_abs_change": np.nan,
+        "rmse": np.nan,
+        "reference_sum": np.nan,
+        "current_sum": np.nan,
+        "sum_change": np.nan,
+        "relative_sum_change_percent": np.nan,
+        "reference_mean": np.nan,
+        "current_mean": np.nan,
+        "mean_change": np.nan,
+        "first_changed_index": "",
+    }
+
+
+def _column_impact(
+    output_name: str,
+    variable: object,
+    reference: pd.DataFrame,
+    current: pd.DataFrame,
+) -> dict:
+    reference_series, current_series, same = _comparison_mask(
+        reference[variable], current[variable]
+    )
+    dtype_equal = reference[variable].dtype == current[variable].dtype
+    index_equal = reference.index.equals(current.index)
+    changed_count = int((~same).sum())
+    first_changed = ""
+    if changed_count:
+        first_changed = str(same.index[~same][0])
+
+    numeric = is_numeric_dtype(reference_series) and is_numeric_dtype(current_series)
+    if numeric:
+        delta = current_series - reference_series
+        absolute = delta.abs()
+        reference_sum = _sum(reference_series)
+        current_sum = _sum(current_series)
+        sum_change = current_sum - reference_sum
+        relative_sum_change = (
+            sum_change / abs(reference_sum) * 100
+            if reference_sum != 0 and np.isfinite(reference_sum)
+            else np.nan
+        )
+        max_abs_change = _safe_float(absolute.max())
+        mean_abs_change = _safe_float(absolute.mean())
+        rmse = _safe_float(np.sqrt((delta**2).mean()))
+        reference_mean = _safe_float(reference_series.mean())
+        current_mean = _safe_float(current_series.mean())
+        mean_change = current_mean - reference_mean
+    else:
+        max_abs_change = mean_abs_change = rmse = np.nan
+        reference_sum = current_sum = sum_change = np.nan
+        relative_sum_change = np.nan
+        reference_mean = current_mean = mean_change = np.nan
+
+    status = (
+        "unchanged"
+        if changed_count == 0 and dtype_equal and index_equal
+        else "changed"
+    )
+    return {
+        "output": output_name,
+        "process": classify_process(output_name, variable),
+        "variable": str(variable),
+        "status": status,
+        "reference_dtype": str(reference[variable].dtype),
+        "current_dtype": str(current[variable].dtype),
+        "index_equal": index_equal,
+        "reference_rows": len(reference),
+        "current_rows": len(current),
+        "reference_missing": int(reference[variable].isna().sum()),
+        "current_missing": int(current[variable].isna().sum()),
+        "changed_count": changed_count,
+        "max_abs_change": max_abs_change,
+        "mean_abs_change": mean_abs_change,
+        "rmse": rmse,
+        "reference_sum": reference_sum,
+        "current_sum": current_sum,
+        "sum_change": sum_change,
+        "relative_sum_change_percent": relative_sum_change,
+        "reference_mean": reference_mean,
+        "current_mean": current_mean,
+        "mean_change": mean_change,
+        "first_changed_index": first_changed,
+    }
+
+
+def build_variable_impact_report(current_output, reference_output) -> pd.DataFrame:
+    """Return one quantitative comparison row for every maintained variable."""
+    rows = []
+    for position, output_name in FRAME_OUTPUTS.items():
+        reference = reference_output[position]
+        current = current_output[position]
+        variables = list(reference.columns) + [
+            variable for variable in current.columns if variable not in reference.columns
+        ]
+        for variable in variables:
+            if variable not in current.columns:
+                rows.append(
+                    _missing_column_row(
+                        output_name, variable, "missing", reference, current
+                    )
+                )
+            elif variable not in reference.columns:
+                rows.append(
+                    _missing_column_row(output_name, variable, "added", reference, current)
+                )
+            else:
+                rows.append(_column_impact(output_name, variable, reference, current))
+
+    reference_kge = float(reference_output[2])
+    current_kge = float(current_output[2])
+    delta = current_kge - reference_kge
+    rows.append(
+        {
+            "output": "model_efficiency",
+            "process": "runoff",
+            "variable": "KGE",
+            "status": "unchanged" if current_kge == reference_kge else "changed",
+            "reference_dtype": type(reference_output[2]).__name__,
+            "current_dtype": type(current_output[2]).__name__,
+            "index_equal": True,
+            "reference_rows": 1,
+            "current_rows": 1,
+            "reference_missing": int(np.isnan(reference_kge)),
+            "current_missing": int(np.isnan(current_kge)),
+            "changed_count": int(current_kge != reference_kge),
+            "max_abs_change": abs(delta),
+            "mean_abs_change": abs(delta),
+            "rmse": abs(delta),
+            "reference_sum": reference_kge,
+            "current_sum": current_kge,
+            "sum_change": delta,
+            "relative_sum_change_percent": (
+                delta / abs(reference_kge) * 100 if reference_kge != 0 else np.nan
+            ),
+            "reference_mean": reference_kge,
+            "current_mean": current_kge,
+            "mean_change": delta,
+            "first_changed_index": "metric" if delta else "",
+        }
+    )
+    return pd.DataFrame(rows)
+
+
+def build_annual_impact_report(current_output, reference_output) -> pd.DataFrame:
+    """Summarize pointwise, mean, and total changes for each calendar year."""
+    rows = []
+    for position, output_name in FRAME_OUTPUTS.items():
+        reference = reference_output[position]
+        current = current_output[position]
+        if not isinstance(reference.index, pd.DatetimeIndex) or not isinstance(
+            current.index, pd.DatetimeIndex
+        ):
+            continue
+        for variable in reference.columns.intersection(current.columns, sort=False):
+            if not (
+                is_numeric_dtype(reference[variable])
+                and is_numeric_dtype(current[variable])
+            ):
+                continue
+            reference_series, current_series, same = _comparison_mask(
+                reference[variable], current[variable]
+            )
+            data = pd.DataFrame(
+                {
+                    "reference": reference_series,
+                    "current": current_series,
+                    "same": same,
+                }
+            )
+            for year, group in data.groupby(data.index.year):
+                delta = group["current"] - group["reference"]
+                reference_sum = _sum(group["reference"])
+                current_sum = _sum(group["current"])
+                reference_mean = _safe_float(group["reference"].mean())
+                current_mean = _safe_float(group["current"].mean())
+                rows.append(
+                    {
+                        "output": output_name,
+                        "process": classify_process(output_name, variable),
+                        "variable": str(variable),
+                        "year": int(year),
+                        "changed_count": int((~group["same"]).sum()),
+                        "max_abs_point_change": _safe_float(delta.abs().max()),
+                        "rmse": _safe_float(np.sqrt((delta**2).mean())),
+                        "reference_sum": reference_sum,
+                        "current_sum": current_sum,
+                        "sum_change": current_sum - reference_sum,
+                        "reference_mean": reference_mean,
+                        "current_mean": current_mean,
+                        "mean_change": current_mean - reference_mean,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def exact_output_errors(current_output, reference_output) -> list[str]:
+    """Return concise structural or numerical errors for maintained outputs."""
+    errors = []
+    if len(current_output) != len(reference_output):
+        errors.append(
+            f"public output length: current={len(current_output)}, "
+            f"reference={len(reference_output)}"
+        )
+    for position, output_name in FRAME_OUTPUTS.items():
+        try:
+            assert_frame_equal(
+                current_output[position],
+                reference_output[position],
+                check_exact=True,
+                check_dtype=True,
+                check_index_type=True,
+                check_column_type=True,
+                check_names=True,
+                check_freq=True,
+            )
+        except AssertionError as error:
+            message = "\n".join(str(error).splitlines()[:8])
+            errors.append(f"{output_name}: {message}")
+    if not np.array_equal(
+        np.asarray(current_output[2]),
+        np.asarray(reference_output[2]),
+        equal_nan=True,
+    ):
+        errors.append(
+            f"KGE: current={current_output[2]!r}, reference={reference_output[2]!r}"
+        )
+    return errors
+
+
+def format_impact_summary(report: pd.DataFrame, maximum_rows: int = 40) -> str:
+    """Format the largest changed variables for a pytest failure message."""
+    changed = report[report["status"] != "unchanged"].copy()
+    if changed.empty:
+        return "No per-variable value changes were found."
+    changed["sort_change"] = changed["max_abs_change"].fillna(-1)
+    changed = changed.sort_values(
+        ["sort_change", "changed_count"], ascending=False
+    ).head(maximum_rows)
+    return changed[
+        [
+            "output",
+            "process",
+            "variable",
+            "status",
+            "changed_count",
+            "max_abs_change",
+            "rmse",
+            "sum_change",
+            "first_changed_index",
+        ]
+    ].to_string(index=False)
+
+
+def write_impact_reports(
+    directory: Path,
+    variable_report: pd.DataFrame,
+    annual_report: pd.DataFrame,
+) -> None:
+    """Write machine-readable diagnostics for scientific impact assessment."""
+    directory.mkdir(parents=True, exist_ok=True)
+    variable_report.to_csv(
+        directory / "variable_impact.csv", index=False, float_format="%.17g"
+    )
+    annual_report.to_csv(
+        directory / "annual_impact.csv", index=False, float_format="%.17g"
+    )
+    changed = variable_report[variable_report["status"] != "unchanged"]
+    summary = {
+        "python": platform.python_version(),
+        "matilda": metadata.version("matilda"),
+        "compared_variables": int(len(variable_report)),
+        "changed_variables": int(len(changed)),
+        "changed_processes": sorted(changed["process"].unique().tolist()),
+        "reports": ["variable_impact.csv", "annual_impact.csv"],
+    }
+    (directory / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )

--- a/tests/impact.py
+++ b/tests/impact.py
@@ -1,4 +1,4 @@
-"""Detailed numerical impact reporting for MATILDA characterization outputs."""
+"""Detailed numerical impact reporting for MATILDA model output comparisons."""
 
 from __future__ import annotations
 

--- a/tests/scenario.py
+++ b/tests/scenario.py
@@ -1,0 +1,49 @@
+"""Loading and execution helpers for the maintained reference scenario."""
+
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import io
+from pathlib import Path
+import pickle
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import yaml
+
+from matilda.core import matilda_simulation
+
+
+INPUT_DIRECTORY = Path(__file__).parent / "test_input"
+REFERENCE_PATH = INPUT_DIRECTORY / "baseline_output.pickle"
+MANIFEST_PATH = INPUT_DIRECTORY / "baseline_manifest.json"
+
+
+def load_reference():
+    with REFERENCE_PATH.open("rb") as handle:
+        return pickle.load(handle)
+
+
+def run_reference_scenario():
+    """Run the standard 2000-2020 glacier-evolution scenario from fresh inputs."""
+    with (INPUT_DIRECTORY / "parameters.yml").open(encoding="utf-8") as handle:
+        parameters = yaml.safe_load(handle)
+    with (INPUT_DIRECTORY / "settings.yml").open(encoding="utf-8") as handle:
+        settings = yaml.safe_load(handle)
+
+    forcing = pd.read_csv(INPUT_DIRECTORY / "era5.csv")
+    observations = pd.read_csv(INPUT_DIRECTORY / "obs_runoff_example.csv")
+    glacier_profile = pd.read_csv(INPUT_DIRECTORY / "glacier_profile.csv")
+
+    captured_output = io.StringIO()
+    try:
+        with redirect_stdout(captured_output):
+            return matilda_simulation(
+                input_df=forcing,
+                obs=observations,
+                **settings,
+                **parameters,
+                glacier_profile=glacier_profile,
+            )
+    finally:
+        plt.close("all")

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,99 @@
+"""Unit tests for numerical impact diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests.impact import (
+    build_annual_impact_report,
+    build_variable_impact_report,
+    exact_output_errors,
+    write_impact_reports,
+)
+
+
+def _synthetic_outputs():
+    index = pd.to_datetime(["2000-12-31", "2001-12-31"])
+    reference_changed = pd.DataFrame(
+        {
+            "flux": [1.0, 2.0],
+            "state": [np.nan, 4.0],
+            "removed": [3.0, 3.0],
+        },
+        index=index,
+    )
+    current_changed = pd.DataFrame(
+        {
+            "flux": [1.5, 1.0],
+            "state": [np.nan, 5.0],
+            "added": [7.0, 8.0],
+        },
+        index=index,
+    )
+    stable = pd.DataFrame({"stable": [1.0, 2.0]}, index=index)
+    stable_distribution = stable.reset_index(drop=True)
+    reference = [
+        reference_changed,
+        stable.copy(),
+        np.float64(0.5),
+        stable.copy(),
+        stable_distribution.copy(),
+        stable.copy(),
+    ]
+    current = [
+        current_changed,
+        stable.copy(),
+        np.float64(0.4),
+        stable.copy(),
+        stable_distribution.copy(),
+        stable.copy(),
+    ]
+    return current, reference
+
+
+def test_impact_reports_quantify_controlled_changes(tmp_path):
+    current, reference = _synthetic_outputs()
+
+    variable_report = build_variable_impact_report(current, reference)
+    annual_report = build_annual_impact_report(current, reference)
+    flux = variable_report.query(
+        "output == 'compact_daily' and variable == 'flux'"
+    ).iloc[0]
+
+    assert flux["status"] == "changed"
+    assert flux["changed_count"] == 2
+    assert flux["max_abs_change"] == pytest.approx(1.0)
+    assert flux["mean_abs_change"] == pytest.approx(0.75)
+    assert flux["rmse"] == pytest.approx(np.sqrt(0.625))
+    assert flux["sum_change"] == pytest.approx(-0.5)
+    assert flux["first_changed_index"] == "2000-12-31 00:00:00"
+
+    assert variable_report.query("variable == 'removed'").iloc[0]["status"] == (
+        "missing"
+    )
+    assert variable_report.query("variable == 'added'").iloc[0]["status"] == (
+        "added"
+    )
+    assert variable_report.query("variable == 'KGE'").iloc[0]["sum_change"] == (
+        pytest.approx(-0.1)
+    )
+
+    annual_flux = annual_report.query(
+        "output == 'compact_daily' and variable == 'flux'"
+    ).set_index("year")
+    assert annual_flux.loc[2000, "sum_change"] == pytest.approx(0.5)
+    assert annual_flux.loc[2001, "sum_change"] == pytest.approx(-1.0)
+
+    errors = exact_output_errors(current, reference)
+    assert any(error.startswith("compact_daily:") for error in errors)
+    assert any(error.startswith("KGE:") for error in errors)
+
+    write_impact_reports(tmp_path, variable_report, annual_report)
+    assert (tmp_path / "variable_impact.csv").is_file()
+    assert (tmp_path / "annual_impact.csv").is_file()
+    summary = json.loads((tmp_path / "summary.json").read_text())
+    assert summary["changed_variables"] == 5

--- a/tests/test_input/baseline_manifest.json
+++ b/tests/test_input/baseline_manifest.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "reference_file": "baseline_output.pickle",
+  "reference_sha256": "91612660fc4c670b2d46676c0e5278d950e81dec4f91a1b6ec7b67ea814c9152",
+  "core_baseline_commit": "7a7625c9365e21dfe1b9e267b08139774e37c446",
+  "model_version": "1.0.2",
+  "python": "3.11.15",
+  "dependencies": {
+    "HydroErr": "1.24",
+    "hydroeval": "0.1.0",
+    "matplotlib": "3.9.2",
+    "numpy": "1.26.4",
+    "pandas": "2.2.3",
+    "plotly": "5.24.1",
+    "scipy": "1.10.1",
+    "xarray": "2024.10.0",
+    "DateTime": "5.5",
+    "PyYAML": "6.0.2",
+    "spotpy": "1.6.2",
+    "SciencePlots": "2.1.1"
+  },
+  "transitive_test_dependencies": {
+    "contourpy": "1.3.3",
+    "cycler": "0.12.1",
+    "fonttools": "4.63.0",
+    "iniconfig": "2.3.0",
+    "kiwisolver": "1.5.0",
+    "packaging": "26.2",
+    "pillow": "12.3.0",
+    "pluggy": "1.6.0",
+    "Pygments": "2.20.0",
+    "pyparsing": "3.3.2",
+    "pytest": "9.1.1",
+    "python-dateutil": "2.9.0.post0",
+    "pytz": "2026.3.post1",
+    "six": "1.17.0",
+    "tenacity": "9.1.4",
+    "tzdata": "2026.3",
+    "zope.interface": "8.5"
+  },
+  "scenario": {
+    "setup_period": "1998-01-01/1999-12-31",
+    "simulation_period": "2000-01-01/2020-12-31",
+    "glacier_evolution": true,
+    "output_frequency": "M"
+  },
+  "public_output_length": 11,
+  "compared_outputs": {
+    "0": "compact_daily",
+    "1": "full_daily",
+    "2": "model_efficiency",
+    "3": "summary_statistics",
+    "4": "glacier_elevation_distribution",
+    "5": "annual_glacier_evolution"
+  },
+  "comparison_policy": "Exact values, structure, dtypes, indexes, columns, and missing-value positions"
+}

--- a/tests/test_matilda.py
+++ b/tests/test_matilda.py
@@ -1,212 +1,89 @@
-# -*- coding: UTF-8 -*-
-"""
-Script: Automated MATILDA Model Testing Routine
-Author: Phillip Schuster
-Date: 2024-11-25
+"""Full-model characterization tests for the maintained reference scenario."""
 
-Description:
--------------
-This script implements an **automated testing routine** for the MATILDA glacio-hydrological model using `pytest`. It ensures
-consistency and correctness of the model output by comparing the current simulation results with a pre-saved baseline.
+from __future__ import annotations
 
-Key Features:
--------------
-1. **Pytest Integration**:
-   - Fully automated testing framework leveraging `pytest` to validate model outputs.
-   - Provides concise error messages and integration with CI/CD pipelines for continuous testing.
+from hashlib import sha256
+from importlib import metadata
+import platform
 
-2. **Baseline Management**:
-   - Loads a pre-saved baseline output from a pickle file for comparison.
-   - Ensures the baseline remains unchanged during tests.
-
-3. **Output Comparison**:
-   - Compares key elements of the model output:
-     a. Time series data (DataFrame) with column-wise summaries of mean, sum, and maximum differences.
-     b. KGE (Kling-Gupta Efficiency) score for model performance.
-
-4. **Fixtures for Flexibility**:
-   - Modular fixtures for dynamically determining file paths, loading input data, and managing baselines.
-
-5. **Improved Diagnostics**:
-   - Prints detailed differences in DataFrame outputs if a test fails for easier debugging.
-   - Allows better visualization of detected differences in terminal output.
-
-6. **Interactive Environment Support**:
-   - Detects working environments dynamically (e.g., IDE, script execution) for seamless path resolution.
-
-Dependencies:
--------------
-- Python 3.x
-- `pytest`, `numpy`, `pandas`, `matplotlib`, `yaml`, `pickle`
-- MATILDA model modules (`matilda.core`, `matilda.mspot_glacier`)
-
-Usage:
-------
-1. Ensure the required input files are in the specified `test_input` directory:
-   - `parameters.yml`
-   - `settings.yml`
-   - `era5.csv`
-   - `obs_runoff_example.csv`
-   - `swe.csv`
-   - `glacier_profile.csv`
-   - `baseline_output.pickle` (manually created baseline)
-
-2. Run the test:
-    pytest test_matilda.py
-
-
-3. The test will:
-- Compare the current model output with the baseline.
-- Print detailed differences if a test fails.
-- Pass if no significant differences are detected.
-
-4. To add this test to a CI/CD pipeline, ensure all required files are available.
-
-Notes:
-------
-- The baseline file (`baseline_output.pickle`) must be manually created before running the test.
-- If the baseline is missing, the test will fail with an appropriate message.
-- Tolerance for numerical comparisons is set to `1e-3` but can be adjusted as needed.
-
-"""
-
-
-import warnings
-
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="spotpy")
+from matplotlib.figure import Figure as MatplotlibFigure
 import pytest
-import os
-import pandas as pd
-import pickle
-import yaml
-import numpy as np
-from matilda.core import matilda_simulation
-from matilda.mspot_glacier import HiddenPrints
+from plotly.graph_objects import Figure as PlotlyFigure
+
+from tests.impact import (
+    FRAME_OUTPUTS,
+    build_annual_impact_report,
+    build_variable_impact_report,
+    exact_output_errors,
+    format_impact_summary,
+    write_impact_reports,
+)
+from tests.scenario import REFERENCE_PATH
 
 
-@pytest.fixture
-def test_directory():
-    """
-    Determine the test directory path dynamically.
-
-    Returns:
-    --------
-    str:
-        The absolute path to the test directory.
-
-    Raises:
-    -------
-    ValueError:
-        If the working directory cannot be determined.
-    """
-    try:
-        # Case 1: Script execution
-        test_dir = os.path.dirname(os.path.abspath(__file__))
-    except NameError:
-        # Case 2: Interactive environment (e.g., Jupyter, IDE)
-        cwd = os.getcwd()
-        if os.path.basename(cwd) == "tests":
-            test_dir = cwd
-        elif os.path.basename(cwd) == "matilda":
-            test_dir = os.path.join(cwd, "tests")
-        else:
-            raise ValueError(
-                "Unknown working directory. Please specify the directory manually."
-            )
-    return test_dir
-
-
-@pytest.fixture
-def load_inputs(test_directory):
-    """Load test inputs from the specified directory."""
-    inputs = {}
-    with open(f"{test_directory}/test_input/parameters.yml", "r") as f:
-        inputs["parameters"] = yaml.safe_load(f)
-    with open(f"{test_directory}/test_input/settings.yml", "r") as f:
-        inputs["settings"] = yaml.safe_load(f)
-    inputs["data"] = pd.read_csv(f"{test_directory}/test_input/era5.csv")
-    inputs["obs"] = pd.read_csv(f"{test_directory}/test_input/obs_runoff_example.csv")
-    inputs["swe"] = pd.read_csv(f"{test_directory}/test_input/swe.csv")
-    inputs["glacier_profile"] = pd.read_csv(
-        f"{test_directory}/test_input/glacier_profile.csv"
+def test_reference_integrity(reference_manifest):
+    """Prevent the numerical reference from being replaced accidentally."""
+    digest = sha256(REFERENCE_PATH.read_bytes()).hexdigest()
+    assert digest == reference_manifest["reference_sha256"]
+    assert reference_manifest["core_baseline_commit"] == (
+        "7a7625c9365e21dfe1b9e267b08139774e37c446"
     )
-    return inputs
 
 
-@pytest.fixture
-def baseline_file(test_directory):
-    """Fixture for the baseline file path."""
-    return f"{test_directory}/test_input/baseline_output.pickle"
+def test_reference_environment(reference_manifest):
+    """Run characterization checks with the recorded scientific dependencies."""
+    assert platform.python_version() == reference_manifest["python"]
+    assert metadata.version("matilda") == reference_manifest["model_version"]
+    expected_dependencies = {
+        **reference_manifest["dependencies"],
+        **reference_manifest["transitive_test_dependencies"],
+    }
+    installed = {
+        package: metadata.version(package) for package in expected_dependencies
+    }
+    assert installed == expected_dependencies
 
 
-def load_baseline(file_path):
-    """Load the baseline output from a pickle file."""
-    with open(file_path, "rb") as f:
-        return pickle.load(f)
+@pytest.mark.characterization
+def test_public_output_contract(current_output, reference_manifest):
+    """Protect the positions and basic types of the public list result."""
+    assert isinstance(current_output, list)
+    assert len(current_output) == reference_manifest["public_output_length"]
+
+    for position in FRAME_OUTPUTS:
+        assert hasattr(current_output[position], "columns")
+        assert hasattr(current_output[position], "index")
+
+    assert isinstance(current_output[6], MatplotlibFigure)
+    assert isinstance(current_output[7], MatplotlibFigure)
+    assert isinstance(current_output[8], MatplotlibFigure)
+    assert isinstance(current_output[9], PlotlyFigure)
+    assert isinstance(current_output[10], PlotlyFigure)
 
 
-def save_baseline(output, file_path):
-    """Save the model output as a baseline to a pickle file."""
-    with open(file_path, "wb") as f:
-        pickle.dump(output, f)
+@pytest.mark.characterization
+def test_full_numerical_characterization(
+    current_output,
+    reference_output,
+    impact_report_directory,
+):
+    """Compare every maintained numerical output and produce impact diagnostics."""
+    variable_report = build_variable_impact_report(current_output, reference_output)
+    annual_report = build_annual_impact_report(current_output, reference_output)
 
-
-def compare_dataframes(df1, df2, tolerance=1e-3):
-    """
-    Compare two dataframes column by column and return a summary of differences.
-    """
-    summary = {}
-    for col in df1.columns:
-        if col in df2.columns:
-            diff = np.abs(df1[col] - df2[col])
-            if (diff > tolerance).any():
-                summary[col] = {
-                    "mean_diff": round(diff.mean(), 3),
-                    "sum_diff": round(diff.sum(), 3),
-                    "max_diff": round(diff.max(), 3),
-                }
-    return summary
-
-
-def test_simulation_baseline(load_inputs, baseline_file):
-    """
-    Test the MATILDA simulation against a pre-saved baseline.
-    """
-    inputs = load_inputs
-
-    with HiddenPrints():
-        new_output = matilda_simulation(
-            input_df=inputs["data"],
-            obs=inputs["obs"],
-            **inputs["settings"],
-            **inputs["parameters"],
-            glacier_profile=inputs["glacier_profile"],
+    if impact_report_directory is not None:
+        write_impact_reports(
+            impact_report_directory,
+            variable_report,
+            annual_report,
         )
 
-    try:
-        baseline_output = load_baseline(baseline_file)
-    except FileNotFoundError:
+    errors = exact_output_errors(current_output, reference_output)
+    changed = variable_report[variable_report["status"] != "unchanged"]
+    if errors or not changed.empty:
+        details = "\n".join(errors)
+        summary = format_impact_summary(variable_report)
         pytest.fail(
-            "Baseline not found. Ensure you have created a baseline manually before running this test."
+            "Full-model output differs from the maintained reference.\n"
+            f"{details}\n\nChanged variables:\n{summary}"
         )
-
-    # Compare DataFrame outputs
-    new_df = pd.DataFrame(new_output[0])
-    baseline_df = pd.DataFrame(baseline_output[0])
-    df_differences = compare_dataframes(new_df, baseline_df)
-
-    if df_differences:
-        # Convert differences to a DataFrame for better visualization
-        diff_df = pd.DataFrame(df_differences).T
-        print("\nDataFrame Differences (detailed):")
-        print(diff_df.to_string())  # Use to_string() for a readable format
-
-    # Assert no differences
-    assert (
-        not df_differences
-    ), f"Significant differences to baseline detected: {df_differences}"
-
-    # Compare KGE metric
-    assert np.isclose(
-        new_output[2], baseline_output[2], atol=1e-3
-    ), f"KGE mismatch: New {new_output[2]} vs Baseline {baseline_output[2]}"

--- a/tests/test_matilda.py
+++ b/tests/test_matilda.py
@@ -1,4 +1,4 @@
-"""Full-model characterization tests for the maintained reference scenario."""
+"""Model output consistency tests for the maintained reference scenario."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ def test_reference_integrity(reference_manifest):
 
 
 def test_reference_environment(reference_manifest):
-    """Run characterization checks with the recorded scientific dependencies."""
+    """Run consistency checks with the recorded scientific dependencies."""
     assert platform.python_version() == reference_manifest["python"]
     assert metadata.version("matilda") == reference_manifest["model_version"]
     expected_dependencies = {
@@ -44,7 +44,7 @@ def test_reference_environment(reference_manifest):
     assert installed == expected_dependencies
 
 
-@pytest.mark.characterization
+@pytest.mark.model_consistency
 def test_public_output_contract(current_output, reference_manifest):
     """Protect the positions and basic types of the public list result."""
     assert isinstance(current_output, list)
@@ -61,8 +61,8 @@ def test_public_output_contract(current_output, reference_manifest):
     assert isinstance(current_output[10], PlotlyFigure)
 
 
-@pytest.mark.characterization
-def test_full_numerical_characterization(
+@pytest.mark.model_consistency
+def test_full_model_output_consistency(
     current_output,
     reference_output,
     impact_report_directory,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,52 @@
+"""Package metadata and resource checks."""
+
+from __future__ import annotations
+
+import ast
+from importlib import metadata, resources
+import json
+from pathlib import Path
+
+import yaml
+
+import matilda
+
+
+PROJECT_ROOT = Path(__file__).parents[1]
+
+
+def _assigned_string(path: Path, name: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} is not assigned in {path}")
+
+
+def test_version_metadata_is_consistent():
+    expected = "1.0.2"
+    citation = yaml.safe_load((PROJECT_ROOT / "CITATION.cff").read_text())
+    zenodo = json.loads((PROJECT_ROOT / ".zenodo.json").read_text())
+
+    assert matilda.__version__ == expected
+    assert metadata.version("matilda") == expected
+    assert _assigned_string(PROJECT_ROOT / "docs/conf.py", "release") == expected
+    assert citation["version"] == expected
+    assert zenodo["version"] == expected
+
+
+def test_parameter_resource_has_documented_defaults():
+    resource = resources.files("matilda").joinpath("parameters.json")
+    parameters = json.loads(resource.read_text(encoding="utf-8"))["parameters"]
+
+    assert len(parameters) == 23
+    assert parameters["CFMAX_snow"]["default"] == 2.5
+    assert parameters["hydro_year"]["default"] == 10
+    assert parameters["pfilter"]["default"] == 0
+
+
+def test_public_modules_are_importable():
+    assert matilda.core.__name__ == "matilda.core"
+    assert matilda.mspot_glacier.__name__ == "matilda.mspot_glacier"

--- a/tests/verify_wheel.py
+++ b/tests/verify_wheel.py
@@ -1,0 +1,74 @@
+"""Verify that a MATILDA wheel contains the maintained package sources."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from email.parser import Parser
+from pathlib import Path
+import zipfile
+
+
+PACKAGE_FILES = {
+    "matilda/__init__.py",
+    "matilda/core.py",
+    "matilda/mspot_glacier.py",
+    "matilda/parameters.json",
+}
+
+
+def source_version(project_root: Path) -> str:
+    tree = ast.parse((project_root / "matilda/__init__.py").read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__version__":
+                    return ast.literal_eval(node.value)
+    raise AssertionError("matilda.__version__ is not assigned")
+
+
+def verify_wheel(wheel_path: Path, project_root: Path) -> None:
+    with zipfile.ZipFile(wheel_path) as archive:
+        members = set(archive.namelist())
+        package_members = {
+            member for member in members if member.startswith("matilda/")
+        }
+        assert package_members == PACKAGE_FILES, (
+            f"unexpected package contents: {sorted(package_members)}"
+        )
+        assert not any(".DS_Store" in member for member in members)
+        assert not any(
+            member.startswith(("build/", "dist/", "docs/_build/"))
+            for member in members
+        )
+
+        for member in PACKAGE_FILES:
+            assert archive.read(member) == (project_root / member).read_bytes(), (
+                f"wheel member does not match maintained source: {member}"
+            )
+
+        metadata_member = next(
+            member for member in members if member.endswith(".dist-info/METADATA")
+        )
+        wheel_metadata = Parser().parsestr(
+            archive.read(metadata_member).decode("utf-8")
+        )
+        assert wheel_metadata["Version"] == source_version(project_root)
+        assert wheel_metadata["Requires-Python"] == ">=3.11"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path(__file__).parents[1],
+    )
+    arguments = parser.parse_args()
+    verify_wheel(arguments.wheel.resolve(), arguments.project_root.resolve())
+    print(f"Verified {arguments.wheel.name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

  This pull request establishes reproducible model output checks for MATILDA 1.0.2.

  It:

  - adds a pinned Python 3.11 test environment;
  - compares the maintained 2000–2020 glacier-evolution scenario with the existing numerical reference;
  - verifies the public output structure, numerical tables, KGE, summary statistics, and glacier-
  evolution outputs;
  - produces variable-level and annual reports that quantify the effect of future model changes;
  - checks package version metadata, parameter defaults, public imports, and wheel contents;
  - runs the checks in GitHub Actions.

  ## Purpose

  The tests record the current model behavior before changes are made to the core routines. The reports
  show which variables, processes, and years are affected by a future change. This helps determine which
  simulations, figures, tables, or calibrations need to be repeated.

  ## Validation

  - Test suite: 8 passed
  - The maintained numerical scenario matches the reference exactly.
  - Wheel-content verification passed.
  - No scientific model routine or equation was changed.

  The current reference covers one long glacier-evolution scenario. Additional synthetic edge-case and
  calibration tests will be added separately.